### PR TITLE
Updates for 1.21.2+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ repositories {
 
 dependencies {
     // Paper
-    compileOnly("io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.3-R0.1-SNAPSHOT")
 
     // Skript
     compileOnly(group: 'com.github.SkriptLang', name: 'Skript', version: '2.8.7') {
@@ -42,7 +42,7 @@ dependencies {
     }
 
     // commons-io
-    compileOnly("commons-io:commons-io:2.11.0")
+    compileOnly('commons-io:commons-io:2.14.0')
     compileOnly("org.apache.commons:commons-text:1.10.0")
 
     // NBT-API

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     compileOnly("org.apache.commons:commons-text:1.10.0")
 
     // NBT-API
-    implementation("de.tr7zw:item-nbt-api:2.13.2") {
+    implementation("de.tr7zw:item-nbt-api:2.14.0") {
         transitive = false
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/api/particle/ParticleUtil.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/particle/ParticleUtil.java
@@ -31,7 +31,7 @@ import java.util.Map;
 /**
  * Utility class for {@link Particle particles}
  */
-@SuppressWarnings("CallToPrintStackTrace")
+@SuppressWarnings({"CallToPrintStackTrace", "UnstableApiUsage"})
 public class ParticleUtil {
 
     private ParticleUtil() {
@@ -39,6 +39,8 @@ public class ParticleUtil {
 
     private static final Map<String, Particle> PARTICLES = new HashMap<>();
     private static final Map<Particle, String> PARTICLE_NAMES = new HashMap<>();
+    // Added in Minecraft 1.21.2
+    public static final boolean HAS_TARGET_COLOR = Skript.classExists("org.bukkit.Particle$TargetColor");
 
     static {
         // Added in Spigot 1.20.2 (oct 20/2023)
@@ -145,6 +147,8 @@ public class ParticleUtil {
             return "number(float)";
         } else if (dataType == Color.class) {
             return "color/bukkitcolor";
+        } else if (HAS_TARGET_COLOR && dataType == Particle.TargetColor.class) {
+            return "targetColor";
         }
         // For future particle data additions that haven't been added here yet
         Util.debug("Missing particle data type: '&e" + dataType.getName() + "&7'");
@@ -200,6 +204,8 @@ public class ParticleUtil {
                     return material.createBlockData();
                 }
             }
+        } else if (HAS_TARGET_COLOR && dataType == Particle.TargetColor.class && data instanceof Particle.TargetColor) {
+            return data;
         }
         return null;
     }

--- a/src/main/java/com/shanebeestudios/skbee/api/reflection/ReflectionConstants.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/reflection/ReflectionConstants.java
@@ -13,16 +13,18 @@ public class ReflectionConstants {
     // net.minecraft.nbt.TextComponentTagVisitor -> visit(Tag)
     public static String TAG_VISITOR_VISIT_METHOD = get("visit", "a");
     // net.minecraft.world.entity.Entity -> noPhysics
-    public static String ENTITY_NO_PHYSICS_FIELD = get("noPhysics", "Q", "Q", "ae", "af", "ag");
+    public static String ENTITY_NO_PHYSICS_FIELD = get("noPhysics", "Q", "Q", "ae", "af", "ag", "ad");
     // net.minecraft.world.scores.PlayerTeam -> setPlayerPrefix
     public static String NMS_SCOREBOARD_TEAM_SET_PREFIX_METHOD = get("setPlayerPrefix", "b");
     // net.minecraft.world.scores.PlayerTeam -> setPlayerSuffix
     public static String NMS_SCOREBOARD_TEAM_SET_SUFFIX_METHOD = get("setPlayerSuffix", "c");
 
     @SuppressWarnings("SameParameterValue")
-    private static String get(String mapped, String v118, String v119, String v1194, String v1202, String v1205) {
+    private static String get(String mapped, String v118, String v119, String v1194, String v1202, String v1205, String v1212) {
         if (REMAPPED_SERVER) {
             return mapped;
+        } else if (Skript.isRunningMinecraft(1, 21, 2)) {
+            return v1212;
         } else if (Skript.isRunningMinecraft(1, 20, 5)) {
             return v1205;
         } else if (Skript.isRunningMinecraft(1, 20, 2)) {

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecFoodComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecFoodComponent.java
@@ -20,26 +20,30 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.components.FoodComponent;
+import org.bukkit.potion.PotionEffect;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.entry.EntryContainer;
 import org.skriptlang.skript.lang.entry.EntryValidator;
 import org.skriptlang.skript.lang.entry.util.ExpressionEntryData;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.List;
 
-@SuppressWarnings("DataFlowIssue")
+@SuppressWarnings({"DataFlowIssue", "UnstableApiUsage"})
 @Name("ItemComponent - Food Component Apply")
 @Description({"Apply a food component to any item making it an edible item. Requires Minecraft 1.20.5+",
     "See [**McWiki Food Component**](https://minecraft.wiki/w/Data_component_format#food) for more details.",
+    "**NOTE**: `eat time`, `using converts to` and the `effects` section were all removed in Minecraft 1.21.2.",
     "",
     "**Entries/Sections**:",
     "- `nutrition` = The number of food points restored by this item when eaten. Must be a non-negative integer.",
     "- `saturation` = The amount of saturation restored by this item when eaten.",
     "- `can always eat` = If true, this item can be eaten even if the player is not hungry. Defaults to false. [Optional]",
-    "- `eat time` = The number of seconds taken by this item to be eaten. Defaults to 1.6 seconds. [Optional]",
-    "- `using converts to` = The item to replace this item with when it is eaten. [Optional] (Requires Minecraft 1.21+)",
-    "- `effects:` = A section to apply potion effects to this food item. [Optional]"})
+    "- `eat time` = The number of seconds taken by this item to be eaten. Defaults to 1.6 seconds. [Optional] (Requires Minecraft 1.21/1.21.1)",
+    "- `using converts to` = The item to replace this item with when it is eaten. [Optional] (Requires Minecraft 1.21/1.21.1)",
+    "- `effects:` = A section to apply potion effects to this food item. [Optional] (Removed in Minecraft 1.21.2)"})
 @Examples({"# Directly apply a food component to the player's tool",
     "apply food component to player's tool:",
     "\tnutrition: 5",
@@ -78,11 +82,17 @@ public class SecFoodComponent extends Section {
     }
 
     private static boolean HAS_CONVERT = false;
+    private static boolean HAS_EAT_SECONDS = false;
+    private static boolean HAS_EFFECTS = false;
+    private static Method EAT_SECONDS_METHOD;
+    private static Method USING_CONVERTS_TO_METHOD;
     private static final EntryValidator.EntryValidatorBuilder VALIDATIOR = EntryValidator.builder();
 
     static {
         if (Skript.classExists("org.bukkit.inventory.meta.components.FoodComponent")) {
             HAS_CONVERT = Skript.methodExists(FoodComponent.class, "setUsingConvertsTo", ItemStack.class);
+            HAS_EAT_SECONDS = Skript.methodExists(FoodComponent.class, "setEatSeconds", float.class);
+            HAS_EFFECTS = Skript.methodExists(FoodComponent.class, "addEffect", PotionEffect.class, float.class);
             VALIDATIOR.addEntryData(new ExpressionEntryData<>("nutrition", null, false, Number.class));
             VALIDATIOR.addEntryData(new ExpressionEntryData<>("saturation", null, false, Number.class));
             VALIDATIOR.addEntryData(new ExpressionEntryData<>("can always eat", null, true, Boolean.class));
@@ -90,6 +100,20 @@ public class SecFoodComponent extends Section {
             VALIDATIOR.addEntryData(new ExpressionEntryData<>("using converts to", null, true, ItemType.class));
             VALIDATIOR.addSection("effects", true);
             Skript.registerSection(SecFoodComponent.class, "apply food component to %itemtypes%");
+            if (HAS_CONVERT) {
+                try {
+                    USING_CONVERTS_TO_METHOD = FoodComponent.class.getDeclaredMethod("setUsingConvertsTo", ItemStack.class);
+                } catch (NoSuchMethodException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            if (HAS_EAT_SECONDS) {
+                try {
+                    EAT_SECONDS_METHOD = FoodComponent.class.getDeclaredMethod("setEatSeconds", float.class);
+                } catch (NoSuchMethodException e) {
+                    throw new RuntimeException(e);
+                }
+            }
         }
     }
 
@@ -112,13 +136,21 @@ public class SecFoodComponent extends Section {
         this.saturation = (Expression<Number>) container.getOptional("saturation", false);
         this.canAlwaysEat = (Expression<Boolean>) container.getOptional("can always eat", false);
         this.eatTime = (Expression<Timespan>) container.getOptional("eat time", false);
+        if (this.eatTime != null && !HAS_EAT_SECONDS) {
+            Skript.error("'eat time' requires Minecraft 1.21 or 1.21.1");
+            return false;
+        }
         this.usingConverts = (Expression<ItemType>) container.getOptional("using converts to", false);
         if (this.usingConverts != null && !HAS_CONVERT) {
-            Skript.error("'using converts to' requires Minecraft 1.21+");
+            Skript.error("'using converts to' requires Minecraft 1.21 or 1.21.1");
             return false;
         }
         SectionNode potionEffects = container.getOptional("effects", SectionNode.class, false);
         if (potionEffects != null) {
+            if (!HAS_EFFECTS) {
+                Skript.error("'effects' was removed in Minecraft 1.21.2");
+                return false;
+            }
             this.potionEffectSection = loadCode(potionEffects, "potion effects", FoodComponentApplyEvent.class);
         }
         return true;
@@ -147,9 +179,11 @@ public class SecFoodComponent extends Section {
             food.setNutrition(nutrition);
             food.setSaturation(saturation);
             food.setCanAlwaysEat(canAlwaysEat);
-            if (eatTime != null) food.setEatSeconds((float) eatTime.getTicks() / 20);
+            if (HAS_EAT_SECONDS && eatTime != null) {
+                setEatSeconds(food, (float) eatTime.getTicks() / 20);
+            }
             if (HAS_CONVERT && usingConvertsTo != null) {
-                food.setUsingConvertsTo(usingConvertsTo);
+                setUsingConverts(food, usingConvertsTo);
             }
 
             if (this.potionEffectSection != null) {
@@ -169,6 +203,26 @@ public class SecFoodComponent extends Section {
     @Override
     public @NotNull String toString(Event e, boolean d) {
         return "apply food component to " + this.items.toString(e, d);
+    }
+
+    private static void setEatSeconds(FoodComponent food, float seconds) {
+        if (EAT_SECONDS_METHOD != null) {
+            try {
+                EAT_SECONDS_METHOD.invoke(food, seconds);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private static void setUsingConverts(FoodComponent food, ItemStack usingConvertsTo) {
+        if (USING_CONVERTS_TO_METHOD != null) {
+            try {
+                USING_CONVERTS_TO_METHOD.invoke(food, usingConvertsTo);
+            } catch (InvocationTargetException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffBlockLock.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffBlockLock.java
@@ -1,0 +1,71 @@
+package com.shanebeestudios.skbee.elements.other.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Lockable;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+@Name("Apply Lock to Block")
+@Description("Apply an item as a lock for a block. Requires Minecraft 1.21.2+")
+@Examples({"apply lock to target block using player's tool",
+    "apply lock to {_blocks::*} using stick named \"Mr Locky\"",
+    "remove lock from target block"})
+@Since("INSERT VERSION")
+public class EffBlockLock extends Effect {
+
+    static {
+        if (Skript.isRunningMinecraft(1, 21, 2)) {
+            Skript.registerEffect(EffBlockLock.class, "apply lock to %blocks% using %itemstack%",
+                "(remove|clear) lock (of|from) %blocks%");
+        }
+    }
+
+    private Expression<Block> blocks;
+    private Expression<ItemStack> item;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        this.blocks = (Expression<Block>) exprs[0];
+        if (matchedPattern == 0) {
+            this.item = (Expression<ItemStack>) exprs[1];
+        }
+        return true;
+    }
+
+    @SuppressWarnings({"NullableProblems", "UnstableApiUsage"})
+    @Override
+    protected void execute(Event event) {
+        if (this.blocks == null) return;
+
+        ItemStack itemStack = this.item != null ? this.item.getSingle(event) : null;
+
+        for (Block block : this.blocks.getArray(event)) {
+            BlockState state = block.getState();
+            if (state instanceof Lockable lockable) {
+                lockable.setLockItem(itemStack);
+                state.update(true);
+            }
+        }
+    }
+
+    @Override
+    public @NotNull String toString(Event e, boolean d) {
+        if (this.item != null) {
+            return "remove lock from " + this.blocks.toString(e, d);
+        }
+        return "apply lock to " + this.blocks.toString(e, d) + " using " + this.item.toString(e, d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprLockableKey.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprLockableKey.java
@@ -1,11 +1,15 @@
 package com.shanebeestudios.skbee.elements.other.expressions;
 
+import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.block.Beacon;
 import org.bukkit.block.Block;
@@ -13,17 +17,31 @@ import org.bukkit.block.Container;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
+@SuppressWarnings("deprecation")
 @Name("Key of Block")
-@Description("Get or set the lock of a container or beacon.")
+@Description({"Get or set the lock of a container or beacon.",
+    "Removed in Minecraft 1.21.2.",
+    "See 'Apply Lock to Block' effect to apply an item as a lock to a block."})
 @Examples({"on right click on shulker box or beacon:",
-        "\tclicked block is locked",
-        "\tplayer has permission \"see.locked\"",
-        "\tsend action bar \"%container key of clicked block%\" to player"})
+    "\tclicked block is locked",
+    "\tplayer has permission \"see.locked\"",
+    "\tsend action bar \"%container key of clicked block%\" to player"})
 @Since("2.16.0")
 public class ExprLockableKey extends SimplePropertyExpression<Block, String> {
 
+    private static final boolean INVALID = Skript.isRunningMinecraft(1, 21, 2);
+
     static {
         register(ExprLockableKey.class, String.class, "(container|lockable) key", "blocks");
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        if (INVALID) {
+            Skript.warning("String based container locks have been removed in Minecraft 1.21.2.");
+        }
+        return super.init(exprs, matchedPattern, isDelayed, parseResult);
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/particle/effects/EffParticle.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/particle/effects/EffParticle.java
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.Nullable;
     "`delta` = a vector with the maximum random offset. The position of each particle will be randomized positively and negatively by the offset parameters on each axis.",
     "Some particles use the delta to set color/direction if count is set to 0.",
     "`extra` = the extra data for this particle, depends on the particle used (normally speed).",
-    "`forc`e = whether to send the particle to players within an extended range and encourage ",
+    "`force` = whether to send the particle to players within an extended range and encourage ",
     "their client to render it regardless of settings (this only works when not using `for player[s]`) (default = false)",
     "`for %players%` = will only send this particle to a player, not the whole server."})
 @Examples({"make 3 of item particle using diamond at location of player",
@@ -45,8 +45,8 @@ public class EffParticle extends Effect {
 
     static {
         Skript.registerEffect(EffParticle.class,
-            "(lerp|draw|make) %number% [of] %particle% [particle] [using %-itemtype/blockdata/dustoption/dusttransition/vibration" +
-                "/number/color/bukkitcolor%] %directions% %locations% [with (delta|offset) %-vector%] [with extra %-number%] [(1:with force)] [(for|to) %-players%]");
+            "(lerp|draw|make) %number% [of] %particle% [particle] [using %-object%] %directions% %locations% " +
+                "[with (delta|offset) %-vector%] [with extra %-number%] [(1:with force)] [(for|to) %-players%]");
     }
 
     private Expression<Number> count;

--- a/src/main/java/com/shanebeestudios/skbee/elements/particle/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/particle/type/Types.java
@@ -21,6 +21,7 @@ import org.bukkit.Vibration;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+@SuppressWarnings("UnstableApiUsage")
 public class Types {
 
     static {
@@ -99,6 +100,13 @@ public class Types {
             .name(ClassInfo.NO_DOC).user("vibrations?")
             .parser(SkriptUtils.getDefaultParser()));
 
+        if (ParticleUtil.HAS_TARGET_COLOR && Classes.getExactClassInfo(Particle.TargetColor.class) == null) {
+            Classes.registerClass(new ClassInfo<>(Particle.TargetColor.class, "targetcolor")
+                .name(ClassInfo.NO_DOC)
+                .user("target ?colors?")
+                .parser(SkriptUtils.getDefaultParser()));
+        }
+
 
         // == FUNCTIONS ==
 
@@ -167,6 +175,27 @@ public class Types {
                 "Requires MC 1.17+")
             .examples("set {_v} to vibration({loc}, 10 seconds)")
             .since("1.11.1"));
+
+        if (ParticleUtil.HAS_TARGET_COLOR) {
+            //noinspection DataFlowIssue
+            Functions.registerFunction(new SimpleJavaFunction<>("targetColor", new Parameter[]{
+                    new Parameter<>("target", DefaultClasses.LOCATION, true, null),
+                    new Parameter<>("color", DefaultClasses.COLOR, true, null)
+                }, Classes.getExactClassInfo(Particle.TargetColor.class), true) {
+                    @SuppressWarnings("NullableProblems")
+                    @Override
+                    public Particle.TargetColor[] executeSimple(Object[][] params) {
+                        Location target = (Location) params[0][0];
+                        org.bukkit.Color color = ((Color) params[1][0]).asBukkitColor();
+                        return new Particle.TargetColor[]{new Particle.TargetColor(target, color)};
+                    }
+                }).description("Creates a new target color to be used with 'trail' particle.",
+                    "Takes in a location for the target (where the trail heads to) and the color.",
+                    "Requires Minecraft 1.21.2+")
+                .examples("set {_target} to targetColor(location of target block, blue)",
+                    "make 10 of trail using {_target} at location of player")
+                .since("INSERT VERSION");
+        }
     }
 
 }

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -67,6 +67,7 @@ types:
     structure: structure¦s
     structurerotation: structure rotation¦s
     tagresolver: tag resolver¦s
+    targetcolor: target color¦s
     team: team¦s
     teamoption: team options¦s
     teamoptionstatus: team option status¦es


### PR DESCRIPTION
This PR aims to fix some issues with API changes in Minecraft 1.21.2.

- Minecraft removed parts of the food component and have been moved to a new "consumable" component.
This component has not been added to Bukkit yet.
Because the food component API is still "unstable", the methods were removed rather than deprecated hence all the reflection.
- Minecraft changed block locks from string keys to ItemStack predicates. So the expression to get/set the key has been deprecated, and a new effect to lock a block is added
- Added the new TargetColor particle data type along with a function to create a new TargetColor object.
- Update a mapping for Entity NoPhysics
- ~~Update NBT-API (for 1.21.2/3 support)~~

I think this about covers the breaking changes for Bukkit API!