### PR TITLE
Dev/Update - Future Release

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -55,5 +55,5 @@ jobs:
                 uses: SkriptLang/skript-test-action@v1.1
                 with:
                     test_script_directory: src/test/scripts
-                    skript_repo_ref: 2.9.3
+                    skript_repo_ref: 2.9.5
                     extra_plugins_directory: extra-plugins/

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     compileOnly("org.apache.commons:commons-text:1.10.0")
 
     // NBT-API
-    implementation("de.tr7zw:item-nbt-api:2.14.0") {
+    implementation("de.tr7zw:item-nbt-api:2.14.1-SNAPSHOT") { // TODO temporary (update before release)
         transitive = false
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ repositories {
 
 dependencies {
     // Paper
-    compileOnly("io.papermc.paper:paper-api:1.21.3-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
 
     // Skript
     compileOnly(group: 'com.github.SkriptLang', name: 'Skript', version: '2.8.7') {
@@ -100,7 +100,7 @@ shadowJar {
 tasks.register('server', Copy) {
     from shadowJar
     // Change this to wherever you want your jar to build
-    into '/Users/ShaneBee/Desktop/Server/Skript/1-21-2/plugins'
+    into '/Users/ShaneBee/Desktop/Server/Skript/1-21-4/plugins'
 }
 
 publishing {

--- a/src/main/java/com/shanebeestudios/skbee/api/particle/ParticleUtil.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/particle/ParticleUtil.java
@@ -39,8 +39,8 @@ public class ParticleUtil {
 
     private static final Map<String, Particle> PARTICLES = new HashMap<>();
     private static final Map<Particle, String> PARTICLE_NAMES = new HashMap<>();
-    // Added in Minecraft 1.21.2
-    public static final boolean HAS_TARGET_COLOR = Skript.classExists("org.bukkit.Particle$TargetColor");
+    // Added in Minecraft 1.21.4
+    public static final boolean HAS_TRAIL = Skript.classExists("org.bukkit.Particle$Trail");
 
     static {
         // Added in Spigot 1.20.2 (oct 20/2023)
@@ -147,8 +147,8 @@ public class ParticleUtil {
             return "number(float)";
         } else if (dataType == Color.class) {
             return "color/bukkitcolor";
-        } else if (HAS_TARGET_COLOR && dataType == Particle.TargetColor.class) {
-            return "targetColor";
+        } else if (HAS_TRAIL && dataType == Particle.Trail.class) {
+            return "trail";
         }
         // For future particle data additions that haven't been added here yet
         Util.debug("Missing particle data type: '&e" + dataType.getName() + "&7'");
@@ -204,7 +204,7 @@ public class ParticleUtil {
                     return material.createBlockData();
                 }
             }
-        } else if (HAS_TARGET_COLOR && dataType == Particle.TargetColor.class && data instanceof Particle.TargetColor) {
+        } else if (HAS_TRAIL && dataType == Particle.Trail.class && data instanceof Particle.Trail) {
             return data;
         }
         return null;

--- a/src/main/java/com/shanebeestudios/skbee/api/wrapper/EnumWrapper.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/wrapper/EnumWrapper.java
@@ -133,6 +133,7 @@ public final class EnumWrapper<E extends Enum<E>> {
     }
 
     private void registerComparator(Class<E> c) {
+        if (Comparators.comparatorExists(c, c)) return;
         Comparators.registerComparator(c, c, (o1, o2) -> Relation.get(o1.equals(o2)));
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/api/wrapper/EnumWrapper.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/wrapper/EnumWrapper.java
@@ -133,7 +133,7 @@ public final class EnumWrapper<E extends Enum<E>> {
     }
 
     private void registerComparator(Class<E> c) {
-        if (Comparators.comparatorExists(c, c)) return;
+        if (Comparators.exactComparatorExists(c, c)) return;
         Comparators.registerComparator(c, c, (o1, o2) -> Relation.get(o1.equals(o2)));
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/api/wrapper/RegistryClassInfo.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/wrapper/RegistryClassInfo.java
@@ -98,7 +98,7 @@ public class RegistryClassInfo<T extends Keyed> extends ClassInfo<T> {
         this.registry = registry;
         this.prefix = prefix;
         this.suffix = suffix;
-        if (!Comparators.comparatorExists(registryClass, registryClass)) {
+        if (!Comparators.exactComparatorExists(registryClass, registryClass)) {
             Comparators.registerComparator(registryClass, registryClass, (o1, o2) -> Relation.get(o1.equals(o2)));
         }
         if (usage) this.usage(getNames());

--- a/src/main/java/com/shanebeestudios/skbee/api/wrapper/RegistryClassInfo.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/wrapper/RegistryClassInfo.java
@@ -98,7 +98,9 @@ public class RegistryClassInfo<T extends Keyed> extends ClassInfo<T> {
         this.registry = registry;
         this.prefix = prefix;
         this.suffix = suffix;
-        Comparators.registerComparator(registryClass, registryClass, (o1, o2) -> Relation.get(o1.equals(o2)));
+        if (!Comparators.comparatorExists(registryClass, registryClass)) {
+            Comparators.registerComparator(registryClass, registryClass, (o1, o2) -> Relation.get(o1.equals(o2)));
+        }
         if (usage) this.usage(getNames());
         this.parser(new Parser<>() {
             @SuppressWarnings("NullableProblems")

--- a/src/main/java/com/shanebeestudios/skbee/elements/gameevent/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/gameevent/type/Types.java
@@ -8,16 +8,17 @@ import org.bukkit.Registry;
 public class Types {
 
     static {
-
-        Classes.registerClass(RegistryClassInfo.create(Registry.GAME_EVENT, GameEvent.class, "gameevent")
-            .name("Game Event")
-            .user("game ?events?")
-            .description("Represents a Minecraft 'GameEvent', mainly used by Skulk Sensors. Requires MC 1.17+.",
-                "See [**GameEvents**](https://minecraft.wiki/w/Sculk_Sensor#Vibration_frequencies) on McWiki for more details.",
-                "NOTE: These are auto-generated and may differ between server versions.")
-            .after("itemtype")
-            .examples("")
-            .since("1.14.0"));
+        if (Classes.getExactClassInfo(GameEvent.class) == null) {
+            Classes.registerClass(RegistryClassInfo.create(Registry.GAME_EVENT, GameEvent.class, "gameevent")
+                .name("Game Event")
+                .user("game ?events?")
+                .description("Represents a Minecraft 'GameEvent', mainly used by Skulk Sensors. Requires MC 1.17+.",
+                    "See [**GameEvents**](https://minecraft.wiki/w/Sculk_Sensor#Vibration_frequencies) on McWiki for more details.",
+                    "NOTE: These are auto-generated and may differ between server versions.")
+                .after("itemtype")
+                .examples("")
+                .since("1.14.0"));
+        }
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/objective/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/objective/type/Types.java
@@ -18,11 +18,12 @@ import org.jetbrains.annotations.NotNull;
 public class Types {
 
     static {
-        Classes.registerClass(new ClassInfo<>(Objective.class, "objective")
+        if (Classes.getExactClassInfo(Objective.class) == null) {
+            Classes.registerClass(new ClassInfo<>(Objective.class, "objective")
                 .user("objectives?")
                 .name("Scoreboard - Objective")
                 .description("Represents an objective in a scoreboard.",
-                        "When deleting, the objective will be unregistered.")
+                    "When deleting, the objective will be unregistered.")
                 .since("2.6.0")
                 .parser(new Parser<>() {
 
@@ -61,46 +62,51 @@ public class Types {
                         }
                     }
                 }));
-
-        if (Skript.classExists("org.bukkit.scoreboard.Criteria")) {
-            Classes.registerClass(new ClassInfo<>(Criteria.class, "criteria")
-                    .user("criterias?")
-                    .name("Scoreboard - Criteria")
-                    .description("Represents a criteria for a scoreboard objective.",
-                            "See [**Scoreboard Criteria**](https://minecraft.wiki/w/Scoreboard#Criteria) on McWiki for more details.")
-                    .since("2.6.0")
-                    .parser(new Parser<>() {
-
-                        @Override
-                        public boolean canParse(@NotNull ParseContext context) {
-                            return false;
-                        }
-
-                        @Override
-                        public @NotNull String toString(Criteria o, int flags) {
-                            return "criteria " + o.getName();
-                        }
-
-                        @Override
-                        public @NotNull String toVariableNameString(Criteria o) {
-                            return "criteria{name=" + o.getName() + "}";
-                        }
-                    }));
         }
 
-        EnumWrapper<RenderType> RENDER_ENUM = new EnumWrapper<>(RenderType.class);
-        Classes.registerClass(RENDER_ENUM.getClassInfo("rendertype")
+        if (Skript.classExists("org.bukkit.scoreboard.Criteria") && Classes.getExactClassInfo(Criteria.class) == null) {
+            Classes.registerClass(new ClassInfo<>(Criteria.class, "criteria")
+                .user("criterias?")
+                .name("Scoreboard - Criteria")
+                .description("Represents a criteria for a scoreboard objective.",
+                    "See [**Scoreboard Criteria**](https://minecraft.wiki/w/Scoreboard#Criteria) on McWiki for more details.")
+                .since("2.6.0")
+                .parser(new Parser<>() {
+
+                    @Override
+                    public boolean canParse(@NotNull ParseContext context) {
+                        return false;
+                    }
+
+                    @Override
+                    public @NotNull String toString(Criteria o, int flags) {
+                        return "criteria " + o.getName();
+                    }
+
+                    @Override
+                    public @NotNull String toVariableNameString(Criteria o) {
+                        return "criteria{name=" + o.getName() + "}";
+                    }
+                }));
+            }
+
+        if (Classes.getExactClassInfo(RenderType.class) == null) {
+            EnumWrapper<RenderType> RENDER_ENUM = new EnumWrapper<>(RenderType.class);
+            Classes.registerClass(RENDER_ENUM.getClassInfo("rendertype")
                 .user("render ?types?")
                 .name("Scoreboard - Objective Render Type")
                 .description("Controls the way in which an Objective is rendered client side.")
                 .since("2.6.0"));
+        }
 
-        EnumWrapper<DisplaySlot> DISPLAY_ENUM = new EnumWrapper<>(DisplaySlot.class);
-        Classes.registerClass(DISPLAY_ENUM.getClassInfo("displayslot")
+        if (Classes.getExactClassInfo(DisplaySlot.class) == null) {
+            EnumWrapper<DisplaySlot> DISPLAY_ENUM = new EnumWrapper<>(DisplaySlot.class);
+            Classes.registerClass(DISPLAY_ENUM.getClassInfo("displayslot")
                 .user("display ?slots?")
                 .name("Scoreboard - Objective Display Slot")
                 .description("Locations for displaying objectives to the player")
                 .since("2.6.0"));
+        }
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
@@ -198,7 +198,7 @@ public class Types {
                 }));
         }
 
-        if (HAS_ARMOR_TRIM) {
+        if (HAS_ARMOR_TRIM && Classes.getExactClassInfo(ArmorTrim.class) == null) {
             Classes.registerClass(new ClassInfo<>(ArmorTrim.class, "armortrim")
                 .user("armor ?trims?")
                 .name("ArmorTrim")
@@ -225,23 +225,27 @@ public class Types {
                         return toString(o, 0);
                     }
                 }));
+            }
 
-            Classes.registerClass(RegistryClassInfo.create(Registry.TRIM_MATERIAL, TrimMaterial.class, "trimmaterial", null, "material")
-                .user("trim ?materials?")
-                .name("ArmorTrim - TrimMaterial")
-                .description("Represents a material that may be used in an ArmorTrim.",
-                    "NOTE: These are auto-generated and may differ between server versions.")
-                .since("2.13.0"));
+            if (Classes.getExactClassInfo(TrimMaterial.class) == null) {
+                Classes.registerClass(RegistryClassInfo.create(Registry.TRIM_MATERIAL, TrimMaterial.class, "trimmaterial", null, "material")
+                    .user("trim ?materials?")
+                    .name("ArmorTrim - TrimMaterial")
+                    .description("Represents a material that may be used in an ArmorTrim.",
+                        "NOTE: These are auto-generated and may differ between server versions.")
+                    .since("2.13.0"));
+            }
 
-            Classes.registerClass(RegistryClassInfo.create(Registry.TRIM_PATTERN, TrimPattern.class, "trimpattern", null, "pattern")
-                .user("trim ?patterns?")
-                .name("ArmorTrim - TrimPattern")
-                .description("Represents a pattern that may be used in an ArmorTrim.",
-                    "NOTE: These are auto-generated and may differ between server versions.")
-                .since("2.13.0"));
-        }
+            if (Classes.getExactClassInfo(TrimPattern.class) == null) {
+                Classes.registerClass(RegistryClassInfo.create(Registry.TRIM_PATTERN, TrimPattern.class, "trimpattern", null, "pattern")
+                    .user("trim ?patterns?")
+                    .name("ArmorTrim - TrimPattern")
+                    .description("Represents a pattern that may be used in an ArmorTrim.",
+                        "NOTE: These are auto-generated and may differ between server versions.")
+                    .since("2.13.0"));
+            }
 
-        if (HAS_CHUNK_LOAD_LEVEL) {
+        if (HAS_CHUNK_LOAD_LEVEL && Classes.getExactClassInfo(LoadLevel.class) == null) {
             EnumWrapper<LoadLevel> LOAD_LEVEL_ENUM = new EnumWrapper<>(LoadLevel.class, "", "level");
             Classes.registerClass(LOAD_LEVEL_ENUM.getClassInfo("chunkloadlevel")
                 .user("chunk ?load ?levels?")
@@ -254,7 +258,7 @@ public class Types {
                     "- `unloaded_level` = This chunk is not loaded.",
                     "NOTE: These are auto-generated and may differ between server versions.")
                 .since("2.17.0"));
-        }
+            }
 
         if (Classes.getExactClassInfo(EntityEffect.class) == null) {
             EnumWrapper<EntityEffect> ENTITY_EFFECT_ENUM = new EnumWrapper<>(EntityEffect.class);
@@ -269,11 +273,13 @@ public class Types {
             Util.logLoading("You may have to use their EntityEffects in SkBee's 'play entity effect' effect.");
         }
 
-        Classes.registerClass(RegistryClassInfo.create(Registry.MEMORY_MODULE_TYPE, MemoryKey.class, "memory")
-            .user("memor(y|ies)")
-            .name("Memory")
-            .description("Represents the different memories of an entity.",
-                "NOTE: These are auto-generated and may differ between server versions."));
+        if (Classes.getExactClassInfo(MemoryKey.class) == null) {
+            Classes.registerClass(RegistryClassInfo.create(Registry.MEMORY_MODULE_TYPE, MemoryKey.class, "memory")
+                .user("memor(y|ies)")
+                .name("Memory")
+                .description("Represents the different memories of an entity.",
+                    "NOTE: These are auto-generated and may differ between server versions."));
+        }
 
         if (Classes.getExactClassInfo(EquipmentSlot.class) == null) {
             EnumWrapper<EquipmentSlot> SLOT_ENUM = new EnumWrapper<>(EquipmentSlot.class, null, "slot");
@@ -358,51 +364,57 @@ public class Types {
                 .since("3.5.0"));
         }
 
-        Classes.registerClass(new ClassInfo<>(Color.class, "bukkitcolor")
-            .user("bukkit ?colors?")
-            .name("Bukkit Color")
-            .description("Represents a Bukkit color. This is different than a Skript color",
-                "as it adds an alpha channel.")
-            .since("2.8.0")
-            .parser(new Parser<>() {
+        if (Classes.getExactClassInfo(Color.class) == null) {
+            Classes.registerClass(new ClassInfo<>(Color.class, "bukkitcolor")
+                .user("bukkit ?colors?")
+                .name("Bukkit Color")
+                .description("Represents a Bukkit color. This is different than a Skript color",
+                    "as it adds an alpha channel.")
+                .since("2.8.0")
+                .parser(new Parser<>() {
 
-                @SuppressWarnings("NullableProblems")
-                @Override
-                public boolean canParse(ParseContext context) {
-                    return false;
-                }
+                    @SuppressWarnings("NullableProblems")
+                    @Override
+                    public boolean canParse(ParseContext context) {
+                        return false;
+                    }
 
-                @Override
-                public @NotNull String toString(Color bukkitColor, int flags) {
-                    int alpha = bukkitColor.getAlpha();
-                    int red = bukkitColor.getRed();
-                    int green = bukkitColor.getGreen();
-                    int blue = bukkitColor.getBlue();
-                    return String.format("BukkitColor(a=%s,r=%s,g=%s,b=%s)", alpha, red, green, blue);
-                }
+                    @Override
+                    public @NotNull String toString(Color bukkitColor, int flags) {
+                        int alpha = bukkitColor.getAlpha();
+                        int red = bukkitColor.getRed();
+                        int green = bukkitColor.getGreen();
+                        int blue = bukkitColor.getBlue();
+                        return String.format("BukkitColor(a=%s,r=%s,g=%s,b=%s)", alpha, red, green, blue);
+                    }
 
-                @Override
-                public @NotNull String toVariableNameString(Color bukkitColor) {
-                    return toString(bukkitColor, 0);
-                }
-            }));
+                    @Override
+                    public @NotNull String toVariableNameString(Color bukkitColor) {
+                        return toString(bukkitColor, 0);
+                    }
+                }));
+        }
 
-        EnumWrapper<TreeType> TREE_TYPE = new EnumWrapper<>(TreeType.class, "", "tree");
-        Classes.registerClass(TREE_TYPE.getClassInfo("bukkittreetype")
-            .user("bukkit ?tree ?types?")
-            .name("Bukkit Tree Type")
-            .description("Represents the different types of trees.",
-                "NOTE: These are auto-generated and may differ between server versions.")
-            .after("structuretype")
-            .since("3.5.3"));
+        if (Classes.getExactClassInfo(TreeType.class) == null) {
+            EnumWrapper<TreeType> TREE_TYPE = new EnumWrapper<>(TreeType.class, "", "tree");
+            Classes.registerClass(TREE_TYPE.getClassInfo("bukkittreetype")
+                .user("bukkit ?tree ?types?")
+                .name("Bukkit Tree Type")
+                .description("Represents the different types of trees.",
+                    "NOTE: These are auto-generated and may differ between server versions.")
+                .after("structuretype")
+                .since("3.5.3"));
+        }
 
-        EnumWrapper<Pose> POSE = new EnumWrapper<>(Pose.class, "", "pose");
-        Classes.registerClass(POSE.getClassInfo("pose")
-            .user("poses?")
-            .name("Entity Pose")
-            .description("Represents the pose of an entity.",
-                "NOTE: These are auto-generated and may differ between server versions.")
-            .since("3.5.4"));
+        if (Classes.getExactClassInfo(Pose.class) == null) {
+            EnumWrapper<Pose> POSE = new EnumWrapper<>(Pose.class, "", "pose");
+            Classes.registerClass(POSE.getClassInfo("pose")
+                .user("poses?")
+                .name("Entity Pose")
+                .description("Represents the pose of an entity.",
+                    "NOTE: These are auto-generated and may differ between server versions.")
+                .since("3.5.4"));
+        }
 
         if (Skript.classExists("org.bukkit.inventory.EquipmentSlotGroup")) {
             // This class is not an enum, and does not have a registry
@@ -434,34 +446,39 @@ public class Types {
                 }));
         }
 
-        Classes.registerClass(new ClassInfo<>(AttributeModifier.class, "attributemodifier")
-            .user("attribute ?modifiers?")
-            .name("Attribute Modifier")
-            .description("Represents an attribute modifier from an item/living entity.")
-            .parser(new Parser<>() {
 
-                @SuppressWarnings("NullableProblems")
-                @Override
-                public boolean canParse(ParseContext context) {
-                    return false;
-                }
+        if (Classes.getExactClassInfo(AttributeModifier.class) == null) {
+            Classes.registerClass(new ClassInfo<>(AttributeModifier.class, "attributemodifier")
+                .user("attribute ?modifiers?")
+                .name("Attribute Modifier")
+                .description("Represents an attribute modifier from an item/living entity.")
+                .parser(new Parser<>() {
 
-                @Override
-                public @NotNull String toString(AttributeModifier modifier, int flags) {
-                    return ItemUtils.attributeModifierToString(modifier);
-                }
+                    @SuppressWarnings("NullableProblems")
+                    @Override
+                    public boolean canParse(ParseContext context) {
+                        return false;
+                    }
 
-                @Override
-                public @NotNull String toVariableNameString(AttributeModifier o) {
-                    return toString(o, 0);
-                }
-            }));
+                    @Override
+                    public @NotNull String toString(AttributeModifier modifier, int flags) {
+                        return ItemUtils.attributeModifierToString(modifier);
+                    }
 
-        Classes.registerClass(new EnumWrapper<>(AttributeModifier.Operation.class).getClassInfo("attributeoperation")
-            .user("attribute ?operations?")
-            .name("Attribute Modifier Operation")
-            .description("Represents the different operations of an attribute modifer.",
-                "NOTE: These are auto-generated and may differ between server versions."));
+                    @Override
+                    public @NotNull String toVariableNameString(AttributeModifier o) {
+                        return toString(o, 0);
+                    }
+                }));
+        }
+
+        if (Classes.getExactClassInfo(AttributeModifier.Operation.class) == null) {
+            Classes.registerClass(new EnumWrapper<>(AttributeModifier.Operation.class).getClassInfo("attributeoperation")
+                .user("attribute ?operations?")
+                .name("Attribute Modifier Operation")
+                .description("Represents the different operations of an attribute modifer.",
+                    "NOTE: These are auto-generated and may differ between server versions."));
+        }
     }
 
     // FUNCTIONS

--- a/src/main/java/com/shanebeestudios/skbee/elements/particle/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/particle/type/Types.java
@@ -95,26 +95,25 @@ public class Types {
                     }
                 }));
         }
-        
+
         if (Classes.getExactClassInfo(DustTransition.class) == null) {
             Classes.registerClass(new ClassInfo<>(DustTransition.class, "dusttransition")
                 .name(ClassInfo.NO_DOC).user("dust ?transitions?")
                 .parser(SkriptUtils.getDefaultParser()));
         }
-        
+
         if (Classes.getExactClassInfo(DustTransition.class) == null) {
             Classes.registerClass(new ClassInfo<>(Vibration.class, "vibration")
                 .name(ClassInfo.NO_DOC).user("vibrations?")
                 .parser(SkriptUtils.getDefaultParser()));
         }
 
-        if (ParticleUtil.HAS_TARGET_COLOR && Classes.getExactClassInfo(Particle.TargetColor.class) == null) {
-            Classes.registerClass(new ClassInfo<>(Particle.TargetColor.class, "targetcolor")
+        if (ParticleUtil.HAS_TRAIL && Classes.getExactClassInfo(Particle.Trail.class) == null) {
+            Classes.registerClass(new ClassInfo<>(Particle.Trail.class, "trail")
                 .name(ClassInfo.NO_DOC)
-                .user("target ?colors?")
+                .user("trails?")
                 .parser(SkriptUtils.getDefaultParser()));
         }
-
 
         // == FUNCTIONS ==
 
@@ -184,25 +183,27 @@ public class Types {
             .examples("set {_v} to vibration({loc}, 10 seconds)")
             .since("1.11.1"));
 
-        if (ParticleUtil.HAS_TARGET_COLOR) {
+        if (ParticleUtil.HAS_TRAIL) {
             //noinspection DataFlowIssue
-            Functions.registerFunction(new SimpleJavaFunction<>("targetColor", new Parameter[]{
+            Functions.registerFunction(new SimpleJavaFunction<>("trail", new Parameter[]{
                     new Parameter<>("target", DefaultClasses.LOCATION, true, null),
-                    new Parameter<>("color", DefaultClasses.COLOR, true, null)
-                }, Classes.getExactClassInfo(Particle.TargetColor.class), true) {
+                    new Parameter<>("color", DefaultClasses.COLOR, true, null),
+                    new Parameter<>("duration", DefaultClasses.TIMESPAN, true, null)
+                }, Classes.getExactClassInfo(Particle.Trail.class), true) {
                     @SuppressWarnings("NullableProblems")
                     @Override
-                    public Particle.TargetColor[] executeSimple(Object[][] params) {
+                    public Particle.Trail[] executeSimple(Object[][] params) {
                         Location target = (Location) params[0][0];
                         org.bukkit.Color color = ((Color) params[1][0]).asBukkitColor();
-                        return new Particle.TargetColor[]{new Particle.TargetColor(target, color)};
+                        Timespan timespan = (Timespan) params[2][0];
+                        return new Particle.Trail[]{new Particle.Trail(target, color, (int) timespan.getTicks())};
                     }
-                }).description("Creates a new target color to be used with 'trail' particle.",
-                    "Takes in a location for the target (where the trail heads to) and the color.",
-                    "Requires Minecraft 1.21.2+")
-                .examples("set {_target} to targetColor(location of target block, blue)",
-                    "make 10 of trail using {_target} at location of player")
-                .since("3.6.2");
+                }).description("Creates a new trail to be used with 'trail' particle.",
+                    "Takes in a location for the target (where the trail heads to), the color and duration.",
+                    "Requires Minecraft 1.21.4+")
+                .examples("set {_trail} to trail(location of target block, blue, 1 second)",
+                    "make 10 of trail using {_trail} at location of player")
+                .since("INSERT VERSION");
         }
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/particle/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/particle/type/Types.java
@@ -102,7 +102,7 @@ public class Types {
                 .parser(SkriptUtils.getDefaultParser()));
         }
 
-        if (Classes.getExactClassInfo(DustTransition.class) == null) {
+        if (Classes.getExactClassInfo(Vibration.class) == null) {
             Classes.registerClass(new ClassInfo<>(Vibration.class, "vibration")
                 .name(ClassInfo.NO_DOC).user("vibrations?")
                 .parser(SkriptUtils.getDefaultParser()));

--- a/src/main/java/com/shanebeestudios/skbee/elements/particle/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/particle/type/Types.java
@@ -61,44 +61,52 @@ public class Types {
             Util.logLoading("You may have to use their particles in SkBee's 'particle spawn' effect.");
         }
 
-        Classes.registerClass(new ClassInfo<>(Particle.DustOptions.class, "dustoption")
-            .name(ClassInfo.NO_DOC).user("dust ?options?")
-            .parser(new Parser<>() {
-                @SuppressWarnings("NullableProblems")
-                @Override
-                public boolean canParse(ParseContext context) {
-                    return false;
-                }
-
-                @Override
-                public @NotNull String toString(Particle.DustOptions dustOption, int flags) {
-                    org.bukkit.Color bukkitColor = dustOption.getColor();
-                    int red = bukkitColor.getRed();
-                    int green = bukkitColor.getGreen();
-                    int blue = bukkitColor.getBlue();
-                    SkriptColor skriptColor = SkriptColor.fromBukkitColor(bukkitColor);
-
-                    String color;
-                    //noinspection ConstantConditions
-                    if (skriptColor != null) {
-                        color = skriptColor.toString();
-                    } else {
-                        color = String.format("rgb(%s,%s,%s)", red, green, blue);
+        if (Classes.getExactClassInfo(Particle.DustOptions.class) == null) {
+            Classes.registerClass(new ClassInfo<>(Particle.DustOptions.class, "dustoption")
+                .name(ClassInfo.NO_DOC).user("dust ?options?")
+                .parser(new Parser<>() {
+                    @SuppressWarnings("NullableProblems")
+                    @Override
+                    public boolean canParse(ParseContext context) {
+                        return false;
                     }
-                    return "dustOption(color=" + color + ",size=" + dustOption.getSize() + ")";
-                }
 
-                @Override
-                public @NotNull String toVariableNameString(Particle.DustOptions o) {
-                    return toString(o, 0);
-                }
-            }));
-        Classes.registerClass(new ClassInfo<>(DustTransition.class, "dusttransition")
-            .name(ClassInfo.NO_DOC).user("dust ?transitions?")
-            .parser(SkriptUtils.getDefaultParser()));
-        Classes.registerClass(new ClassInfo<>(Vibration.class, "vibration")
-            .name(ClassInfo.NO_DOC).user("vibrations?")
-            .parser(SkriptUtils.getDefaultParser()));
+                    @Override
+                    public @NotNull String toString(Particle.DustOptions dustOption, int flags) {
+                        org.bukkit.Color bukkitColor = dustOption.getColor();
+                        int red = bukkitColor.getRed();
+                        int green = bukkitColor.getGreen();
+                        int blue = bukkitColor.getBlue();
+                        SkriptColor skriptColor = SkriptColor.fromBukkitColor(bukkitColor);
+
+                        String color;
+                        //noinspection ConstantConditions
+                        if (skriptColor != null) {
+                            color = skriptColor.toString();
+                        } else {
+                            color = String.format("rgb(%s,%s,%s)", red, green, blue);
+                        }
+                        return "dustOption(color=" + color + ",size=" + dustOption.getSize() + ")";
+                    }
+
+                    @Override
+                    public @NotNull String toVariableNameString(Particle.DustOptions o) {
+                        return toString(o, 0);
+                    }
+                }));
+        }
+        
+        if (Classes.getExactClassInfo(DustTransition.class) == null) {
+            Classes.registerClass(new ClassInfo<>(DustTransition.class, "dusttransition")
+                .name(ClassInfo.NO_DOC).user("dust ?transitions?")
+                .parser(SkriptUtils.getDefaultParser()));
+        }
+        
+        if (Classes.getExactClassInfo(DustTransition.class) == null) {
+            Classes.registerClass(new ClassInfo<>(Vibration.class, "vibration")
+                .name(ClassInfo.NO_DOC).user("vibrations?")
+                .parser(SkriptUtils.getDefaultParser()));
+        }
 
         if (ParticleUtil.HAS_TARGET_COLOR && Classes.getExactClassInfo(Particle.TargetColor.class) == null) {
             Classes.registerClass(new ClassInfo<>(Particle.TargetColor.class, "targetcolor")

--- a/src/main/java/com/shanebeestudios/skbee/elements/recipe/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/recipe/type/Types.java
@@ -22,17 +22,18 @@ import java.util.List;
 public class Types {
 
     static {
-        Classes.registerClass(new ClassInfo<>(RecipeChoice.class, "recipechoice")
+        if (Classes.getExactClassInfo(RecipeChoice.class) == null) {
+            Classes.registerClass(new ClassInfo<>(RecipeChoice.class, "recipechoice")
                 .name("Recipe Choice")
                 .user("recipe ?choices?")
                 .description("Represents an Exact/Material Choice.",
-                        "MaterialChoice represents a set of materials/minecraft tags which can be used in some recipes.",
-                        "ExactChoice represents a special ItemStack used in some recipes.",
-                        "Requires Minecraft 1.13+")
+                    "MaterialChoice represents a set of materials/minecraft tags which can be used in some recipes.",
+                    "ExactChoice represents a special ItemStack used in some recipes.",
+                    "Requires Minecraft 1.13+")
                 .usage("see material choice expression")
                 .examples("set {_a} to material choice of diamond sword, diamond shovel and diamond hoe",
-                        "set {_a} to material choice of every sword",
-                        "set {_a} to material choice of minecraft tag \"doors\"")
+                    "set {_a} to material choice of every sword",
+                    "set {_a} to material choice of minecraft tag \"doors\"")
                 .after("itemtype", "itemstack")
                 .since("1.10.0")
                 .parser(new Parser<>() {
@@ -53,6 +54,7 @@ public class Types {
                         return "recipechoice:" + toString(matChoice, 0);
                     }
                 }));
+        }
 
         EnumWrapper<RecipeType> RECIPE_TYPE_ENUM = new EnumWrapper<>(RecipeType.class);
         Classes.registerClass(RECIPE_TYPE_ENUM.getClassInfo("recipetype")

--- a/src/main/java/com/shanebeestudios/skbee/elements/statistic/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/statistic/type/Types.java
@@ -14,16 +14,18 @@ import java.util.List;
 public class Types {
 
     static {
-        Classes.registerClass(RegistryClassInfo.create(Registry.STATISTIC, Statistic.class, false, "statistic")
-            .user("statistics?")
-            .name("Statistic")
-            .description("Represents the different statistics for a player.",
-                "Some stats require extra data, these are distinguished by their data type within the square brackets.",
-                "Underscores in stat names are not required, you can use spaces.",
-                "NOTE: 'play_one_minute' stat's name is misleading, it's actually amount of ticks played.",
-                "NOTE: These are auto-generated and may differ between server versions.")
-            .usage(getNames())
-            .since("1.17.0"));
+        if (Classes.getExactClassInfo(Statistic.class) == null) {
+            Classes.registerClass(RegistryClassInfo.create(Registry.STATISTIC, Statistic.class, false, "statistic")
+                .user("statistics?")
+                .name("Statistic")
+                .description("Represents the different statistics for a player.",
+                    "Some stats require extra data, these are distinguished by their data type within the square brackets.",
+                    "Underscores in stat names are not required, you can use spaces.",
+                    "NOTE: 'play_one_minute' stat's name is misleading, it's actually amount of ticks played.",
+                    "NOTE: These are auto-generated and may differ between server versions.")
+                .usage(getNames())
+                .since("1.17.0"));
+        }
     }
 
     /**

--- a/src/main/java/com/shanebeestudios/skbee/elements/structure/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/structure/type/Types.java
@@ -39,21 +39,25 @@ public class Types {
                     }
                 }));
 
-        EnumWrapper<Mirror> MIRROR_ENUM = new EnumWrapper<>(Mirror.class);
-        Classes.registerClass(MIRROR_ENUM.getClassInfo("mirror")
+        if (Classes.getExactClassInfo(Mirror.class) == null) {
+            EnumWrapper<Mirror> MIRROR_ENUM = new EnumWrapper<>(Mirror.class);
+            Classes.registerClass(MIRROR_ENUM.getClassInfo("mirror")
                 .user("mirrors?")
                 .name("Structure - Mirror")
                 .description("Represents the different states of mirroring for a structure. Requires MC 1.17.1+")
                 .examples("set structure mirror of structure {_s} to front back")
                 .since("1.12.0"));
+        }
 
-        EnumWrapper<StructureRotation> ROTATION_ENUM = new EnumWrapper<>(StructureRotation.class);
-        Classes.registerClass(ROTATION_ENUM.getClassInfo("structurerotation")
+        if (Classes.getExactClassInfo(StructureRotation.class) == null) {
+            EnumWrapper<StructureRotation> ROTATION_ENUM = new EnumWrapper<>(StructureRotation.class);
+            Classes.registerClass(ROTATION_ENUM.getClassInfo("structurerotation")
                 .user("structure ?rotations?")
                 .name("Structure - Rotation")
                 .description("Represents the different states of rotation for a structure. Requires MC 1.17.1+")
                 .examples("set structure rotation of structure {_s} to clockwise 90")
                 .since("1.12.0"));
+        }
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/type/Types.java
@@ -81,7 +81,7 @@ public class Types {
             }).changer(COMP_CHANGER)
         );
 
-        if (Skript.classExists("net.kyori.adventure.chat.SignedMessage")) {
+        if (Skript.classExists("net.kyori.adventure.chat.SignedMessage") && Classes.getExactClassInfo(SignedMessage.class) == null) {
             Classes.registerClass(new ClassInfo<>(SignedMessage.class, "signedmessage")
                 .user("signed ?messages?")
                 .name("Signed Chat Message")
@@ -113,21 +113,23 @@ public class Types {
                         }
                     }
                 }));
-        }
+            }
 
-        Classes.registerClass(new ClassInfo<>(TagResolver.class, "tagresolver")
-            .user("tag ?resolvers?")
-            .description("Represents an object to replace text in a mini message.")
-            .examples("# Create a component",
-                "set {_t} to translate component of player's tool",
-                "add hover event showing player's tool to {_t}",
-                "# Use this component in the resolver to replace \"<item>\" in the mini message",
-                "set {_r} to resolver(\"item\", {_t})",
-                "# setup the mini message with the replacement placeholder",
-                "set {_m} to mini message from \"<rainbow> Hey guys check out my <item> aint she a beaut?\" with {_r}",
-                "send component {_m}")
-            .parser(SkriptUtils.getDefaultParser())
-            .since("3.5.0"));
+        if (Classes.getExactClassInfo(TagResolver.class) == null) {
+            Classes.registerClass(new ClassInfo<>(TagResolver.class, "tagresolver")
+                .user("tag ?resolvers?")
+                .description("Represents an object to replace text in a mini message.")
+                .examples("# Create a component",
+                    "set {_t} to translate component of player's tool",
+                    "add hover event showing player's tool to {_t}",
+                    "# Use this component in the resolver to replace \"<item>\" in the mini message",
+                    "set {_r} to resolver(\"item\", {_t})",
+                    "# setup the mini message with the replacement placeholder",
+                    "set {_m} to mini message from \"<rainbow> Hey guys check out my <item> aint she a beaut?\" with {_r}",
+                    "send component {_m}")
+                .parser(SkriptUtils.getDefaultParser())
+                .since("3.5.0"));
+        }
 
         // Functions
         //noinspection DataFlowIssue

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -67,12 +67,12 @@ types:
     structure: structure¦s
     structurerotation: structure rotation¦s
     tagresolver: tag resolver¦s
-    targetcolor: target color¦s
     team: team¦s
     teamoption: team options¦s
     teamoptionstatus: team option status¦es
     textalignment: text alignment¦s
     textcomponent: text component¦s @-
+    trail: trail¦s
     transformation: transformation¦s
     transformreason: transform reason¦s
     trimmaterial: trim material¦s

--- a/src/test/scripts/general/nbt-test.sk
+++ b/src/test/scripts/general/nbt-test.sk
@@ -29,9 +29,15 @@ test "SkBee - simple nbt compound":
     assert int tag "minecraft:custom_model_data" of {_n} is set with "tag ""minecraft:custom_model_data"" of an item should be set"
     assert int tag "minecraft:custom_model_data" of {_n} = 1 with "tag ""minecraft:custom_model_data"" of an item should be 1"
 
+    # Test that vanilla NBT of an item works
+    set {_vn} to vanilla nbt of {_i}
+    assert {_vn} is set with "Vanilla NBT of an item should work"
+
     # Test that Pretty nbt works
     set {_pretty} to pretty nbt of {_n}
     assert {_pretty} is set with "Pretty NBT should have worked"
+    set {_vp} to pretty nbt of {_vn}
+    assert {_vp} is set with "Pretty NBT of vanilla nbt should have worked"
 
     # Test adding/removing to/from lists
     set {_n} to empty nbt compound

--- a/src/test/scripts/general/particle.sk
+++ b/src/test/scripts/general/particle.sk
@@ -1,0 +1,20 @@
+test "SkBee - particle":
+    # Test that these particles don't cause errors
+    set {_l} to spawn of world "world"
+
+    make 10 of block using dirt at {_l}
+    make 10 of dust using dustOption(red, 5) at {_l} with extra 0
+    make 1 of item using diamond sword at {_l} with offset vector(1,1,1) with force
+
+    set {_trans} to dustTransition(red, green, 3)
+    make 3 of dust_color_transition using {_trans} at {_l}
+
+    set {_l2} to {_l} ~ vector(3,3,3)
+    set {_vib} to vibration({_l2}, 5 seconds)
+    make 1 of vibration using {_vib} at {_l}
+
+test "SkBee - particle with trail" when running minecraft "1.21.4":
+    set {_l1} to spawn of world "world"
+    set {_l2} to location 5 above {_l1}
+    set {_trail} to trail({_l1}, blue, 10 seconds)
+    make 10 of trail using {_trail} at {_l2}


### PR DESCRIPTION
This PR is showing what is happening in the next release:

Temp changelog:
## REMOVED:
- Particle Data `TargetColor` Type/Function have been removed (Bukkit removed the class)
Since SkBee only supports the latest release of each major MC version, and since this was 1.21.3 ONLY, theres no need to do any crazy reflection to make this work. (See `Trail` below)

## ADDED:
- Added preliminary 1.21.4 support (light testing has been done, but everything seems to work as intended)
- Particle Data `Trail` Type/Function have been added (a replacement for TargetColor, but also contains a timespan)

## CHANGED:
- Comparators - only auto-register comparators if they don't exist
- Changed some ClassInfos to only register if they're not registered already by Skript/Addon (#14 thanks @JakeGBLP )